### PR TITLE
Prepare release 26.7.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,21 +1,12 @@
 # Change Log
 
-## Unreleased
-
-<!-- PR authors:
-     Please include the PR number in the changelog entry, not the issue number -->
+## Version 26.7.0
 
 - Add support for NO_COLOR environment variable to disable ANSI output (#5129)
 - No spurious target version warning when runtime version is included in a
   --target-version flag (#5167)
 
-### Highlights
-
-<!-- Include any especially major or disruptive changes here -->
-
 ### Stable style
-
-<!-- Changes that affect Black's stable style -->
 
 - Fix crash when a standalone comment sits between tokens of a comprehension or lambda
   (#5144)
@@ -31,8 +22,6 @@
   previously crashing) (#5161)
 
 ### Preview style
-
-<!-- Changes that affect Black's preview style -->
 
 - Fix unnecessary parentheses around short RHS expressions in indexed assignments like
   `x[key] = expr` (#5095)
@@ -51,8 +40,6 @@
 
 ### Configuration
 
-<!-- Changes to how Black can be configured -->
-
 - Fix `find_project_root` returning a stale cached result when `--code` is used from
   different working directories in the same process. The CWD fallback (used when no
   `srcs` are given) is now resolved before the `lru_cache` key is computed, so each
@@ -66,18 +53,10 @@
 
 ### Packaging
 
-<!-- Changes to how Black is packaged, such as dependency requirements -->
-
 - Reduce the size of Linux standalone binaries by stripping debug symbols during the
   PyInstaller release build (#5223)
 
-### Parser
-
-<!-- Changes to the parser or to version autodetection -->
-
 ### Performance
-
-<!-- Changes that improve Black's performance. -->
 
 - Improve performance on strings containing many consecutive backslashes (#5163)
 - Improve performance when merging implicitly concatenated f-strings whose expressions
@@ -127,23 +106,6 @@
   search for each converted block within its parent's child list from the previous
   conversion's position instead of rescanning the whole list from the start on every
   node removal (#5232)
-
-### Output
-
-<!-- Changes to Black's terminal output and error messages -->
-
-### _Blackd_
-
-<!-- Changes to blackd -->
-
-### Integrations
-
-<!-- For example, Docker, GitHub Actions, pre-commit, editors -->
-
-### Documentation
-
-<!-- Major changes to documentation and policies. Small docs changes
-     don't need a changelog entry. -->
 
 ## Version 26.5.1
 

--- a/docs/guides/using_black_with_jupyter_notebooks.md
+++ b/docs/guides/using_black_with_jupyter_notebooks.md
@@ -111,7 +111,7 @@ Simply replace the `black` hook with `black-jupyter`.
 ```yaml
 repos:
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 26.5.1
+    rev: 26.7.0
     hooks:
       - id: black-jupyter
         language_version: python3.11

--- a/docs/integrations/source_version_control.md
+++ b/docs/integrations/source_version_control.md
@@ -8,7 +8,7 @@ Use [pre-commit](https://pre-commit.com/). Once you
 repos:
   # Using this mirror lets us use mypyc-compiled black, which is about 2x faster
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 26.5.1
+    rev: 26.7.0
     hooks:
       - id: black
         # It is recommended to specify the latest version of Python
@@ -34,7 +34,7 @@ include Jupyter Notebooks. To use this hook, simply replace the hook's `id: blac
 ```yaml
 repos:
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 26.5.1
+    rev: 26.7.0
     hooks:
       - id: black-jupyter
         language_version: python3.11
@@ -64,7 +64,7 @@ Configure exclusions directly in `.pre-commit-config.yaml`:
 ```yaml
 repos:
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 26.5.1
+    rev: 26.7.0
     hooks:
       - id: black
         exclude: ^migrations/|^generated/

--- a/docs/usage_and_configuration/the_basics.md
+++ b/docs/usage_and_configuration/the_basics.md
@@ -280,8 +280,8 @@ configuration file for consistent results across environments.
 
 ```console
 $ black --version
-black, 26.5.1 (compiled: yes)
-$ black --required-version 26.5.1 -c "format = 'this'"
+black, 26.7.0 (compiled: yes)
+$ black --required-version 26.7.0 -c "format = 'this'"
 format = "this"
 $ black --required-version 31.5b2 -c "still = 'beta?!'"
 Oh no! 💥 💔 💥 The required version does not match the running version!
@@ -388,7 +388,7 @@ You can check the version of _Black_ you have installed using the `--version` fl
 
 ```console
 $ black --version
-black, 26.5.1
+black, 26.7.0
 ```
 
 #### `--config`


### PR DESCRIPTION
Please follow the process in [the docs](https://black.readthedocs.io/en/latest/contributing/release_process.html#cutting-a-release) to cut a release.
<details><summary>Changelog Diff</summary>

```diff
diff --git a/CHANGES.md b/CHANGES.md
index b710349a..e2b30238 100644
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,112 @@
 # Change Log
 
+## Version 26.7.0
+
+- Add support for NO_COLOR environment variable to disable ANSI output (#5129)
+- No spurious target version warning when runtime version is included in a
+  --target-version flag (#5167)
+
+### Stable style
+
+- Fix crash when a standalone comment sits between tokens of a comprehension or lambda
+  (#5144)
+- Fix crash when a comment-only `# fmt: off`/`# fmt: on` block is followed by a `with`
+  statement after another standalone comment (#5189)
+- Fix a crash when splitting `case case if ...` match patterns at very small line
+  lengths (#5147)
+- Fix multiline docstring indentation when leading tabs are used inside indented
+  docstrings (#5148)
+- Respect `# fmt: skip` on a line that opens a bracket (e.g.
+  `from x import (  # fmt: skip`) when a standalone comment is among the bracket's
+  contents: the whole statement is now preserved instead of being reformatted (and
+  previously crashing) (#5161)
+
+### Preview style
+
+- Fix unnecessary parentheses around short RHS expressions in indexed assignments like
+  `x[key] = expr` (#5095)
+- Parenthesize tuple expressions in `yield` statements for consistency with function
+  calls and returns (#5170)
+- Stop splitting between a variable and its comparator (`not in`, `==`, `is`, ...) when
+  the right-hand side is a bracketed expression. Black now lets the bracket explode
+  instead. This fixes the awkward break that was showing up in comprehension `if`
+  clauses (#4514) as well as the same shape inside `if`, `elif`, `assert`, and
+  parenthesized expressions (#5135)
+- In `.pyi` stub files, enforce a blank line after a function or method that has a
+  docstring-only body when another comment or statement follows it (#5158)
+- Keep the parentheses around a lambda used as the iterable of a comprehension (e.g.
+  `[x for x in (lambda: 0) if x]`). They were previously stripped by
+  `wrap_comprehension_in`, which produced invalid code and crashed Black (#5176)
+
+### Configuration
+
+- Fix `find_project_root` returning a stale cached result when `--code` is used from
+  different working directories in the same process. The CWD fallback (used when no
+  `srcs` are given) is now resolved before the `lru_cache` key is computed, so each
+  directory gets the correct `pyproject.toml` (#5152)
+- Add validation for --line-ranges values (#5107)
+- Ignore empty cache files like other malformed cache files instead of raising an
+  `EOFError` (#5192)
+- Reject non-string `include` and `force-exclude` values in `pyproject.toml` (#5193)
+- Validate `BLACK_NUM_WORKERS` values and report invalid values as usage errors instead
+  of crashing (#5211)
+
+### Packaging
+
+- Reduce the size of Linux standalone binaries by stripping debug symbols during the
+  PyInstaller release build (#5223)
+
+### Performance
+
+- Improve performance on strings containing many consecutive backslashes (#5163)
+- Improve performance when merging implicitly concatenated f-strings whose expressions
+  contain long string literals (#5165)
+- Improve performance on files with many `# fmt: skip`/`# fmt: off` comments by no
+  longer re-walking the whole tree from the root for every directive (#5169)
+- Improve performance on deeply nested parenthesised expressions by no longer
+  re-scanning the whole atom for every nesting level in `max_delimiter_priority_in_atom`
+  (#5171)
+- Improve performance when merging long runs of implicitly concatenated strings by no
+  longer re-escaping the whole accumulated string on every merge step (#5173)
+  sibling-maps-incremental
+- Improve performance on code whose formatting rewrites large nodes (such as `--preview`
+  string processing) by maintaining the `blib2to3` sibling-node maps incrementally
+  rather than rebuilding them from scratch after every tree mutation (#5178)
+- Improve performance on long calls and collections by no longer scanning the whole line
+  to locate each bracket's opening pair in `is_one_sequence_between` (#5177)
+- Improve performance on functions and other blocks containing many `# fmt: skip`
+  comments by no longer scanning every leaf of the enclosing block for each directive
+  when checking for a semicolon-separated inline body (#5190)
+- Improve performance when merging large groups of implicitly concatenated strings by no
+  longer rebuilding a node's children list and sibling maps from scratch on every
+  `replace` call (#5194)
+- Improve performance on lines holding a multiline string inside a large collection (for
+  example a dict literal whose values are all triple-quoted strings) by locating the
+  string's enclosing nodes via leaf membership instead of re-rendering each enclosing
+  node to a string in `is_line_short_enough` (#5188)
+- Improve performance on files with many soft-keyword constructs (such as `match`/`case`
+  blocks) by discarding spent token-lookahead ranges in the parser instead of
+  re-scanning all of them for every token (#5186)
+- Improve performance when splitting long string literals (preview string processing) by
+  no longer re-scanning the whole string for `\N{...}` named escapes on every substring
+  (#5183)
+- Improve performance on large dict literals and long semicolon-separated statements by
+  wrapping a node's children in invisible parentheses in place instead of removing and
+  re-inserting each one, which scanned the whole child list every time (#5184)
+- Improve performance when copying a long line's leaves into a new line (for example
+  `--preview` string processing of `"%s ..." % (a, b, c, ...)` or a string with a
+  backslash continuation) by resuming the child lookup in `append_leaves` instead of
+  rescanning each leaf's parent from the start (#5199)
+- Improve performance of `--line-ranges` on files with many sibling blocks (a long
+  `if`/`elif` chain, a `match` with many cases, or many top-level definitions) by
+  splicing the unchanged blocks into each parent's child list in a single pass rather
+  than removing and re-inserting each one, which rescanned and shifted the whole child
+  list on every conversion (#5213)
+- Improve performance on files with many `# fmt: off`/`# fmt: on` blocks by resuming the
+  search for each converted block within its parent's child list from the previous
+  conversion's position instead of rescanning the whole list from the start on every
+  node removal (#5232)
+
 ## Version 26.5.1
 
 ### Stable style
```

</details>
